### PR TITLE
Ajout-valeurs-1C

### DIFF
--- a/JSON_1C/valeurAccompagnateurs.json
+++ b/JSON_1C/valeurAccompagnateurs.json
@@ -1,0 +1,13 @@
+{"accompagnateurs":[{
+    "accompagnateurId":0,
+    "nom":"Buisson",
+    "prenom":"Marie",
+    "mail":"marieBuisson@mail.com",
+    "telephone":"07 77 77 77 76",
+    "datePermis":"2020-01-01T12:00:00.000Z",
+    "documentPermis":"./permis/permis.pdf",
+    "documentAccordAssureur": "./assurances/assuranceBuisson.pdf",
+    "casierVierge":true,
+    "documentCasierVierge":"./casiers/extraitCasierBuisson.pdf"
+}]
+}

--- a/JSON_1C/valeurConducteur.json
+++ b/JSON_1C/valeurConducteur.json
@@ -1,0 +1,12 @@
+{
+    "conducteurs":[{
+        "conducteurId":0,
+        "nom":"Buisson",
+        "prenom":"Patrick",
+        "mail":"patrickbuisson@mail.com",
+        "telephone":"06 66 66 66 67",
+        "motDePasse":"Patrickbuisson05971",
+        "entretiensObligatoires":[0,1],
+        "listeTrajets":[0,1]
+    }]
+}

--- a/JSON_1C/valeurEntretiens.json
+++ b/JSON_1C/valeurEntretiens.json
@@ -1,0 +1,10 @@
+{"entretiensObligatoires":[
+    {
+        "idEntretien":0,
+        "dateEntretien":"2024-02-11T15:30:00.000Z",
+        "nomEnseignant":"Boissière",
+        "prenomEnseignant": "Sylvie",
+        "agence":"Boissière Routière"
+    }
+]
+}

--- a/JSON_1C/valeurExercice.json
+++ b/JSON_1C/valeurExercice.json
@@ -1,0 +1,6 @@
+{"exercices":[
+    {"exerciceId":0, "exerciceNom": "Stationnement en épi"},
+    {"exerciceId":1, "exerciceNom":"Stationnement en bataille"},
+    {"exerciceId":2, "exerciceNom":"Stationnement en créneau"}
+]
+}

--- a/JSON_1C/valeurTrafic.json
+++ b/JSON_1C/valeurTrafic.json
@@ -1,0 +1,8 @@
+{
+    "trafic":[
+        {"traficId":0, "typeTrafic":"Faible"},
+        {"traficId":1, "typeTrafic":"Modéré"},
+        {"traficId":2, "typeTrafic":"Fort"},
+        {"traficId":3, "typeTrafic":"Fluctuant"}
+    ]
+}

--- a/JSON_1C/valeurTypeRoute.json
+++ b/JSON_1C/valeurTypeRoute.json
@@ -1,0 +1,9 @@
+{
+    "typeRoute":[
+        {"typeRouteId":0, "typeRouteNom":"Nationale"},
+        {"typeRouteId":1, "typeRouteNom":"Départementale"},
+        {"typeRouteId":2, "typeRouteNom":"Autoroute"},
+        {"typeRouteId":3, "typeRouteNom":"Centre-ville"},
+        {"typeRouteId":4, "typeRouteNom":"Mixte"}
+    ]
+}

--- a/JSON_1C/valeurVehicule.json
+++ b/JSON_1C/valeurVehicule.json
@@ -1,0 +1,7 @@
+{"vehiculeEnregistres":[{
+    "vehiculeId":0,
+    "proprietaire": 0,
+    "nomVehicule": "XY-789-AB",
+    "typeBoite": 0
+}]
+}


### PR DESCRIPTION
Hello,

Comme expliqué dans le commit sur la propriété météo, dans 1B, je propose de découper nos dossiers/documents en suivant les consignes pas à pas.

L'exercice 1C demande de juste faire différentes conditions de valeurs. C'est pour ça que je propose dans le dossier 1C de mettre chaque document JSON comme travaillé précédemment. J'ai quand même ajouté les valeurs accompagnateurs et véhicule, même si on prévoit de ne les ajouter que dans un deuxième temps.
>  Soit on les supprime, soit on les garde.
> Dans le document regroupant l'ensemble des valeurs, les valeurs accompagnateurs et véhicule seront de simple "string" pour l'instant.

On en parle ce soir !